### PR TITLE
Sentor devel: New Features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,4 @@
 ﻿
-
-
-﻿
-
-
 > # ROS messages monitoring node
 
 Continuously monitor topic messages. Send warnings and execute other processes when certain conditions on the messages are satisfied. 
@@ -156,7 +151,7 @@ Child arguments of `log`:
 ## Safety critical conditions
 A topic monitor's signal when condition, and each of its lambda expressions, can be tagged as *safety critical*. If any safety critical condition in any topic monitor is satisfied then the boolean message from the topic `safe operation` will be set to False. 
 
-By setting the arg `auto_safety_tagging` (see `sentor.launch`) to True sentor will automatically set safe operation to True when all safety critical condition across all monitors are unsatisfied.  If `auto_safety_tagging` is set to `False` then the service `/sentor/set_safety_tag` must be called.
+By setting the arg `auto_safety_tagging` (see `sentor.launch`) to True sentor will automatically set `safe operation` to True when all safety critical condition across all monitors are unsatisfied.  If `auto_safety_tagging` is set to `False` then the service `/sentor/set_safety_tag` must be called.
 
 ## Using sentor with this example config
 You will need the RASberry repo (<a href="https://github.com/LCAS/RASberry">get it here</a>) and all its dependencies. Also install `cowsay`. Create a file `.rasberryrc` in your home directory and put the following inside it:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 ﻿
 
 
+﻿
+
+
 > # ROS messages monitoring node
 
 Continuously monitor topic messages. Send warnings and execute other processes when certain conditions on the messages are satisfied. 
@@ -45,6 +48,7 @@ The config file contains the list of topics to be monitored and the definition, 
   timeout: 0.0
   lock_exec: False
   repeat_exec: False
+  default_notifications: True
   include: True                  
 
 
@@ -55,12 +59,9 @@ The config file contains the list of topics to be monitored and the definition, 
   - expression: "lambda msg: msg.feedback.route == 'WayPoint45'"
     safety_critical: False
   execute:
-  - log:
-      message: "Resetting safety tag"
-      level: info
   - call:
       verbose: True
-      service_name: "/sentor/reset_safety_tag"
+      service_name: "/sentor/set_safety_tag"
       service_args:
       -  "req.data = True"
   - log:
@@ -88,6 +89,7 @@ The config file contains the list of topics to be monitored and the definition, 
   timeout: 0.0
   lock_exec: False
   repeat_exec: False
+  default_notifications: True
   include: True   
 
 
@@ -99,7 +101,7 @@ The config file contains the list of topics to be monitored and the definition, 
 Top-level arguments:
 - `name`: is the name of the topic to monitor
 - `signal_when`: optional, can be either 'not published' or 'published'. Respectively, it will send a warning when the topic is not published or when it is.
-- `safety_critical`: optional (default=False), tag the `signal_when` condition as 'safety critical' (or not). If it is then when it is satisfied the boolean message from the topic `/safe_operation` will be set to 'False'. Call the service `/sentor/reset_safety_tag` to reset this back to 'True'.
+- `safety_critical`: optional (default=False), tag the `signal_when` condition as 'safety critical' (or not). See section 'Safety critical conditions'.
 - `signal_lambdas`: optional, it's a list of (pythonic) lambda expressions such that when they are satisfied a warning is sent. You can use the python package `math` in your lambda expressions. See 'Child arguments of `signal_lambdas`' below.
 - `execute`: optional, a list of processes to execute if `signal_when` is satisfied, or if all lambda expressions are satisfied. They will be executed in sequence. See 'Child arguments of `execute`' below. 
 - `timeout`: optional (default=0.1), amount of time (in seconds) for which the signal has to be satisfied before sending the warning/executing processes.
@@ -110,7 +112,7 @@ Top-level arguments:
 
 Child arguments of `signal_lambdas`:
 - `expression`: the lambda expression.
-- `safety_critical`: optional (default=False), tag this lambda expression as 'safety critical' (or not). If it is then when it is satisfied the boolean message from the topic `/safe_operation` will be set to 'False'. Call the service `/sentor/reset_safety_tag` to reset this back to 'True'.
+- `safety_critical`: optional (default=False), tag this lambda expression as 'safety critical' (or not). See section 'Safety critical conditions'.
 
 Child arguments of `execute`:
 - `call`: optional, call a rosservice.
@@ -150,6 +152,11 @@ Child arguments of `log`:
 - `message`: the message that you are logging.
 - `level`: the log level (can be 'info', 'warn' or 'error').
 - `msg_args`: optional, you can supply message data from the topic you are monitoring in your logs. See the first monitor in the example config.
+
+## Safety critical conditions
+A topic monitor's signal when condition, and each of its lambda expressions, can be tagged as *safety critical*. If any safety critical condition in any topic monitor is satisfied then the boolean message from the topic `safe operation` will be set to False. 
+
+By setting the arg `auto_safety_tagging` (see `sentor.launch`) to True sentor will automatically set safe operation to True when all safety critical condition across all monitors are unsatisfied.  If `auto_safety_tagging` is set to `False` then the service `/sentor/set_safety_tag` must be called.
 
 ## Using sentor with this example config
 You will need the RASberry repo (<a href="https://github.com/LCAS/RASberry">get it here</a>) and all its dependencies. Also install `cowsay`. Create a file `.rasberryrc` in your home directory and put the following inside it:

--- a/config/execute.yaml
+++ b/config/execute.yaml
@@ -39,12 +39,9 @@
   - expression: "lambda msg: msg.feedback.route == 'WayPoint45'"
     safety_critical: False
   execute:
-  - log:
-      message: "Resetting safety tag"
-      level: info
   - call:
       verbose: True
-      service_name: "/sentor/reset_safety_tag"
+      service_name: "/sentor/set_safety_tag"
       service_args:
       -  "req.data = True"
   - log:

--- a/launch/sentor.launch
+++ b/launch/sentor.launch
@@ -3,10 +3,12 @@
 
   <arg name="topics" default=""/>
   <arg name="config_file" default=""/>
+  <arg name="auto_safety_tagging" default="false"/>
   <arg name="safety_pub_rate" default="10.0"/>
 
   <node pkg="sentor" type="sentor_node.py" name="sentor" output="screen">
     <param name="~config_file" value="$(arg config_file)" />
+    <param name="~auto_safety_tagging" value="$(arg auto_safety_tagging)" />
     <param name="~safety_pub_rate" value="$(arg safety_pub_rate)" />
   </node>	
 

--- a/scripts/sentor_node.py
+++ b/scripts/sentor_node.py
@@ -78,6 +78,10 @@ if __name__ == "__main__":
 
     event_pub = rospy.Publisher('/sentor/event', String, queue_size=10)
 
+    safety_pub_rate = rospy.get_param("~safety_pub_rate", "")    
+    auto_safety_tagging = rospy.get_param("~auto_safety_tagging", "")        
+    safety_monitor = SafetyMonitor(safety_pub_rate, auto_safety_tagging, event_callback)
+
     topic_monitors = []
     print "Monitoring topics:"
     for topic in topics:
@@ -117,13 +121,11 @@ if __name__ == "__main__":
 
         if include:
             topic_monitor = TopicMonitor(topic_name, signal_when, safety_critical, 
-                                         signal_lambdas, processes, lock_exec, repeat_exec, timeout, 
-                                         default_notifications, event_callback)
+                                         signal_lambdas, processes, lock_exec, repeat_exec, 
+                                         timeout, default_notifications, event_callback)
             topic_monitors.append(topic_monitor)
+            safety_monitor.register_monitors(topic_monitor)
             
-    safety_pub_rate = rospy.get_param("~safety_pub_rate", "")
-    safety_monitor = SafetyMonitor(safety_pub_rate, topic_monitors)
-
     time.sleep(1)
 
     # start monitoring

--- a/scripts/sentor_node.py
+++ b/scripts/sentor_node.py
@@ -77,9 +77,6 @@ if __name__ == "__main__":
     start_srv = rospy.Service('/sentor/start_monitor', Empty, start_monitoring)
 
     event_pub = rospy.Publisher('/sentor/event', String, queue_size=10)
-    
-    safety_pub_rate = rospy.get_param("~safety_pub_rate", "")
-    safety_monitor = SafetyMonitor(safety_pub_rate)
 
     topic_monitors = []
     print "Monitoring topics:"
@@ -121,8 +118,11 @@ if __name__ == "__main__":
         if include:
             topic_monitor = TopicMonitor(topic_name, signal_when, safety_critical, 
                                          signal_lambdas, processes, lock_exec, repeat_exec, timeout, 
-                                         default_notifications, event_callback, safety_monitor.safety_callback)
+                                         default_notifications, event_callback)
             topic_monitors.append(topic_monitor)
+            
+    safety_pub_rate = rospy.get_param("~safety_pub_rate", "")
+    safety_monitor = SafetyMonitor(safety_pub_rate, topic_monitors)
 
     time.sleep(1)
 

--- a/src/sentor/ROSTopicFilter.py
+++ b/src/sentor/ROSTopicFilter.py
@@ -41,7 +41,7 @@ class ROSTopicFilter(object):
                 func(self.lambda_fn_str, msg, self.safety_critical)
         else:
             for func in self.unsat_callbacks:
-                func(self.lambda_fn_str)
+                func(self.lambda_fn_str, self.safety_critical)
 
 
         # if not self.filter_satisfied and not self.value_read:

--- a/src/sentor/ROSTopicFilter.py
+++ b/src/sentor/ROSTopicFilter.py
@@ -41,7 +41,7 @@ class ROSTopicFilter(object):
                 func(self.lambda_fn_str, msg, self.safety_critical)
         else:
             for func in self.unsat_callbacks:
-                func(self.lambda_fn_str, self.safety_critical)
+                func(self.lambda_fn_str)
 
 
         # if not self.filter_satisfied and not self.value_read:

--- a/src/sentor/SafetyMonitor.py
+++ b/src/sentor/SafetyMonitor.py
@@ -14,18 +14,50 @@ from std_srvs.srv import SetBool, SetBoolResponse
 class SafetyMonitor(object):
     
     
-    def __init__(self, rate, topic_monitors):
+    def __init__(self, rate, auto_tagging, event_cb):
         
-        self.topic_monitors = topic_monitors
-        self.safe_operation = True
+        self.auto_tagging = auto_tagging
+        self.event_cb = event_cb
+        self.topic_monitors = []
+        
+        self.safe_operation = True        
+        self.safe_msg_sent = False
+        self.unsafe_msg_sent = False
 
         self.safety_pub = rospy.Publisher('/safe_operation', Bool, queue_size=10)
         rospy.Timer(rospy.Duration(1.0/rate), self.safety_pub_cb)
         
-        rospy.Service('/sentor/reset_safety_tag', SetBool, self.reset)
+        rospy.Service('/sentor/set_safety_tag', SetBool, self.set_safety_tag)
+
+
+    def register_monitors(self, topic_monitor):
+        self.topic_monitors.append(topic_monitor)
         
         
-    def reset(self, req):
+    def safety_pub_cb(self, event=None):
+        
+        if self.topic_monitors:
+            threads_are_safe = [monitor.thread_is_safe for monitor in self.topic_monitors]
+            
+            if all(threads_are_safe) and self.auto_tagging:
+                self.safe_operation = True
+            elif not all(threads_are_safe):
+                self.safe_operation = False
+                
+            self.safety_pub.publish(Bool(self.safe_operation))
+
+            if all(threads_are_safe) and not self.safe_msg_sent:
+                self.event_cb("SAFE OPERATION: TRUE", "info")
+                self.safe_msg_sent = True
+                self.unsafe_msg_sent = False
+                
+            elif not all(threads_are_safe) and not self.unsafe_msg_sent:
+                self.event_cb("SAFE OPERATION: FALSE", "warn")
+                self.safe_msg_sent = False
+                self.unsafe_msg_sent = True
+        
+        
+    def set_safety_tag(self, req):
         
         self.safe_operation = req.data        
         
@@ -34,16 +66,4 @@ class SafetyMonitor(object):
         ans.message = "safe operation: {}".format(req.data)
         
         return ans
-
-
-    def safety_pub_cb(self, event=None):
-        
-        threads_are_safe = [monitor.thread_is_safe for monitor in self.topic_monitors]
-        
-        if all(threads_are_safe):
-            self.safe_operation = True
-        else:
-            self.safe_operation = False
-            
-        self.safety_pub.publish(Bool(self.safe_operation))
 #####################################################################################

--- a/src/sentor/TopicMonitor.py
+++ b/src/sentor/TopicMonitor.py
@@ -39,6 +39,7 @@ class TopicMonitor(Thread):
         self.event_callback = event_callback
         self.satisfied_expressions = []
         self.sat_expressions_timer = {}
+        self.sat_expr_crit_timer = {}
         self.sat_expr_repeat_timer = {}
         self.pub_monitor = None
         self.hz_monitor = None
@@ -51,8 +52,11 @@ class TopicMonitor(Thread):
 
         if processes:
             self.executor = Executor(processes, lock_exec, event_callback)
-            
+        
+        self.signal_when_is_safe = True
+        self.lambdas_are_safe = True
         self.thread_is_safe = True
+        rospy.Timer(rospy.Duration(0.1), self.safety_cb)
 
         self._stop_event = Event()
         self._killed_event = Event()
@@ -72,10 +76,8 @@ class TopicMonitor(Thread):
         if real_topic is None:
             self.event_callback("Topic %s is not published" % self.topic_name, "warn")
             if self.signal_when.lower() == 'not published' and self.safety_critical:
-                self.thread_is_safe = False
+                self.signal_when_is_safe = False
             return False
-        elif real_topic is not None and self.signal_when.lower() == 'published' and self.safety_critical:
-            self.thread_is_safe = False
 
         if self.signal_when.lower() == 'published':
             print "Signaling 'published' for "+ bcolors.OKBLUE + self.topic_name + bcolors.ENDC +" initialized"
@@ -83,6 +85,9 @@ class TopicMonitor(Thread):
             self.pub_monitor = self._instantiate_pub_monitor(real_topic, self.topic_name, msg_class)
 
             self.pub_monitor.register_published_cb(self.published_cb)
+            
+            if self.safety_critical:
+                self.signal_when_is_safe = False
 
         elif self.signal_when.lower() == 'not published':
             print "Signaling 'not published' for "+ bcolors.BOLD + str(self.timeout) + " seconds" + bcolors.ENDC +" for " + bcolors.OKBLUE + self.topic_name + bcolors.ENDC +" initialized"
@@ -149,20 +154,17 @@ class TopicMonitor(Thread):
                 self.is_instantiated = True
                 
         def cb(_):
+            if self.safety_critical:
+                self.signal_when_is_safe = False
             if self.default_notifications and self.safety_critical:
                 self.event_callback("SAFETY CRITICAL: Topic %s is not published anymore" % self.topic_name, "warn")
             elif self.default_notifications:
                 self.event_callback("Topic %s is not published anymore" % self.topic_name, "warn")
             if not self.repeat_exec:
-                if self.safety_critical:
-                    self.thread_is_safe = False
                 self.execute()
 
         def repeat_cb(_):
-            if self.repeat_exec:
-                if self.safety_critical:
-                    self.thread_is_safe = False
-                self.execute()
+            self.execute()
 
         timer = None
         timer_repeat = None
@@ -190,7 +192,7 @@ class TopicMonitor(Thread):
                         self.is_topic_published = True
                         
                         if self.safety_critical:
-                            self.thread_is_safe = True
+                            self.signal_when_is_safe = True
 
                         if timer is not None:
                             timer.shutdown()
@@ -222,18 +224,25 @@ class TopicMonitor(Thread):
             time.sleep(1)
 
     def lambda_satisfied_cb(self, expr, msg, safety_critical_lambda):
-        if not self._stop_event.isSet():            
+        if not self._stop_event.isSet():         
+            if safety_critical_lambda:
+                if not expr in self.sat_expr_crit_timer.keys():
+                    # self.satisfied_expressions.append(expr)
+                    def crit_cb(_):
+                        self.lambdas_are_safe = False
+                        if self.default_notifications:
+                            self.event_callback("SAFETY CRITICAL: Expression '%s' for %s seconds on topic %s satisfied" % (expr, self.timeout, self.topic_name), "warn", msg)
+                
+                    self._lock.acquire()
+                    self.sat_expr_crit_timer.update({expr: rospy.Timer(rospy.Duration.from_sec(self.timeout), crit_cb, oneshot=True)})
+                    self._lock.release()            
+            
             if not expr in self.sat_expressions_timer.keys():
                 # self.satisfied_expressions.append(expr)
                 def cb(_):
-                    if self.default_notifications and safety_critical_lambda:
-                        self.event_callback("SAFETY CRITICAL: Expression '%s' for %s seconds on topic %s satisfied" % (expr, self.timeout, self.topic_name), "warn", msg)
-                    elif self.default_notifications:
+                    if self.default_notifications and not safety_critical_lambda:
                         self.event_callback("Expression '%s' for %s seconds on topic %s satisfied" % (expr, self.timeout, self.topic_name), "warn", msg)
-                    if not self.repeat_exec:
-                        if safety_critical_lambda:
-                            self.thread_is_safe = False
-                        if len(self.sat_expressions_timer.keys()) == len(self.signal_lambdas):
+                    if not self.repeat_exec and len(self.sat_expressions_timer.keys()) == len(self.signal_lambdas):
                             self.execute(msg)
                 
                 self._lock.acquire()
@@ -242,10 +251,7 @@ class TopicMonitor(Thread):
             
             if self.repeat_exec:
                 if not expr in self.sat_expr_repeat_timer.keys():
-                    
                     def repeat_cb(_):
-                        if safety_critical_lambda:
-                            self.thread_is_safe = False
                         if len(self.sat_expr_repeat_timer.keys()) == len(self.signal_lambdas):
                             self.execute(msg)
                             for expr in self.sat_expr_repeat_timer.keys():
@@ -257,25 +263,28 @@ class TopicMonitor(Thread):
                     self._lock.release()  
             #print "sat", msg
 
-    def lambda_unsatisfied_cb(self, expr, safety_critical_lambda):
+    def lambda_unsatisfied_cb(self, expr):
         if not self._stop_event.isSet():
+            if expr in self.sat_expr_crit_timer.keys():
+                self._lock.acquire()
+                self.sat_expr_crit_timer[expr].shutdown()
+                self.sat_expr_crit_timer.pop(expr)
+                self._lock.release()
+                
+            if not self.sat_expr_crit_timer:
+                self.lambdas_are_safe = True
+            
             if expr in self.sat_expressions_timer.keys():
                 self._lock.acquire()
                 self.sat_expressions_timer[expr].shutdown()
                 self.sat_expressions_timer.pop(expr)
                 self._lock.release()
                 
-                if safety_critical_lambda:
-                    self.thread_is_safe = True
-                
             if expr in self.sat_expr_repeat_timer.keys():
                 self._lock.acquire()
                 self.sat_expr_repeat_timer[expr].shutdown()
                 self.sat_expr_repeat_timer.pop(expr)
                 self._lock.release()
-                
-                if safety_critical_lambda:
-                    self.thread_is_safe = True
             # if not msg in self.unsatisfied_expressions and msg in self.satisfied_expressions:
             #     self.unsatisfied_expressions.append(msg)
             #print "unsat", msg
@@ -283,7 +292,7 @@ class TopicMonitor(Thread):
     def published_cb(self, msg):
         if not self._stop_event.isSet():
             if self.safety_critical:
-                self.thread_is_safe = False
+                self.signal_when_is_safe = False
             if self.default_notifications and self.safety_critical:
                 self.event_callback("SAFETY CRITICAL: Topic %s is published " % (self.topic_name), "warn")
             elif self.default_notifications:
@@ -301,6 +310,13 @@ class TopicMonitor(Thread):
         if self.processes:
             rospy.sleep(0.1) # needed when using slackeros
             self.executor.execute(msg)
+            
+    def safety_cb(self, event=None):
+        
+        if self.signal_when_is_safe and self.lambdas_are_safe:
+            self.thread_is_safe = True
+        else:
+            self.thread_is_safe = False
             
     def stop_monitor(self):
         self._stop_event.set()


### PR DESCRIPTION
By setting the arg `auto_safety_tagging` (see `sentor.launch`) to True
sentor will automatically set `safe operation` to True when all
safety critical condition across all monitors are unsatisfied.
If `auto_safety_tagging` is set to `False` then the (renamed) service
`/sentor/set_safety_tag` must be called.