### PR TITLE
adding /sentor/rich_event topic for structured sentor events information

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ add_message_files(
   FILES
   TopicMap.msg
   TopicMapArray.msg
+  SentorEvent.msg
 )
 
 add_service_files(

--- a/msg/SentorEvent.msg
+++ b/msg/SentorEvent.msg
@@ -1,0 +1,9 @@
+byte INFO=1
+byte WARN=2
+byte ERROR=4
+
+std_msgs/Header header
+byte level
+string message
+string[] nodes
+string topic


### PR DESCRIPTION
This modification adds the `/sentor/rich_event` topic which publishes the classic `/sentor/event` message augmented with:
- the name of the topic
- the name of the ROS nodes that publish on that topic
- the event level (err, warn, info)

It does not replace the `/sentor/event` topic which continues to work as before.

This makes filtering and grouping the events, according to node/topic and level, much easier (e.g. for a monitoring interface)