### PR TITLE
Topic mapping decoupled from topic monitoring.

### DIFF
--- a/config/map.yaml
+++ b/config/map.yaml
@@ -1,17 +1,13 @@
-- name : "/sim_amcl_error"
-  map:
-    topic_arg: "msg.y"
-    stat: "mean"
-    limits: [11.0, 25.0, -40.0, -8.0]
-    resolution: 1.5
-  include: False
-
-
 - name : "/row_detector/health_monitor"
-  map:
-    topic_arg: "msg.lines_accepted.data == False"
-    stat: "mean"
-    limits: [11.0, 25.0, -40.0, -8.0]
-    resolution: 1.5
+  arg: "msg.lines_accepted.data == False"
+  stat: "mean"
+  limits: [11.0, 25.0, -40.0, -8.0]
+  resolution: 1.5
   include: True
 
+- name : "/row_detector/health_monitor"
+  arg: "msg.lines_accepted.data == False"
+  stat: "std"
+  limits: [11.0, 25.0, -40.0, -8.0]
+  resolution: 1.5
+  include: True

--- a/launch/sentor.launch
+++ b/launch/sentor.launch
@@ -6,16 +6,13 @@
   <arg name="safe_operation_timeout" default="10.0"/>
   <arg name="auto_safety_tagging" default="true"/>
   <arg name="safety_pub_rate" default="10.0"/>
-  <arg name="map_pub_rate" default="0"/>
-  <arg name="map_plt_rate" default="0"/>
+
 
   <node pkg="sentor" type="sentor_node.py" name="sentor" output="screen">
     <param name="~config_file" value="$(arg config_file)" />
     <param name="~safe_operation_timeout" value="$(arg safe_operation_timeout)" />
     <param name="~auto_safety_tagging" value="$(arg auto_safety_tagging)" />
     <param name="~safety_pub_rate" value="$(arg safety_pub_rate)" />
-    <param name="~map_pub_rate" value="$(arg map_pub_rate)" />
-    <param name="~map_plt_rate" value="$(arg map_plt_rate)" />
   </node>	
 
 </launch>

--- a/launch/topic_mapping.launch
+++ b/launch/topic_mapping.launch
@@ -1,0 +1,14 @@
+<?xml version="1.0" ?>
+<launch>
+
+  <arg name="config_file" default=""/>
+  <arg name="map_pub_rate" default="0"/>
+  <arg name="map_plt_rate" default="0"/>
+
+  <node pkg="sentor" type="topic_mapping_node.py" name="topic_mapper" output="screen">
+    <param name="~config_file" value="$(arg config_file)" />
+    <param name="~map_pub_rate" value="$(arg map_pub_rate)" />
+    <param name="~map_plt_rate" value="$(arg map_plt_rate)" />
+  </node>	
+
+</launch>

--- a/scripts/topic_mapping_node.py
+++ b/scripts/topic_mapping_node.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+"""
+@author: Adam Binch (abinch@sagarobotics.com)
+"""
+##########################################################################################
+from __future__ import division
+from sentor.TopicMapper import TopicMapper
+from sentor.TopicMapServer import TopicMapServer
+from std_srvs.srv import Empty, EmptyResponse
+
+import signal
+import rospy
+import time
+import yaml
+import os
+##########################################################################################
+
+
+##########################################################################################
+def __signal_handler(signum, frame):
+    def kill_mappers():
+        for topic_mapper in topic_mappers:
+            topic_mapper.kill_mapper()
+    def join_mappers():
+        for topic_mapper in topic_mappers:
+            topic_mapper.join()
+    kill_mappers()
+    join_mappers()
+    print "stopped."
+    os._exit(signal.SIGTERM)
+    
+
+def stop_mapping(_):
+    topic_map_server.stop()
+
+    rospy.logwarn("topic_mapping_node stopped mapping")
+    ans = EmptyResponse()
+    return ans
+    
+
+def start_mapping(_):
+    topic_map_server.start()
+
+    rospy.logwarn("topic_mapping_node started mapping")
+    ans = EmptyResponse()
+    return ans
+##########################################################################################
+    
+
+##########################################################################################
+if __name__ == "__main__":
+    signal.signal(signal.SIGINT, __signal_handler)
+    rospy.init_node("topic_mapper")
+
+    config_file = rospy.get_param("~config_file", "")
+
+    try:
+        topics = yaml.load(file(config_file, 'r'))
+    except Exception as e:
+        rospy.logerr("No configuration file provided: %s" % e)
+        topics = []
+
+    stop_srv = rospy.Service('/sentor/stop_mapping', Empty, stop_mapping)
+    start_srv = rospy.Service('/sentor/start_mapping', Empty, start_mapping)
+
+    topic_mappers = []
+    print "Mapping topics:"
+    for topic in topics:
+        try:
+            topic_name = topic["name"]
+        except Exception as e:
+            rospy.logerr("topic name is not specified for entry %s" % topic)
+            continue
+
+        include = True
+        if "include" in topic.keys():
+            include = topic["include"]
+
+        if include:
+            topic_mappers.append(TopicMapper(topic))
+            
+    time.sleep(1)
+    
+    map_pub_rate = rospy.get_param("~map_pub_rate", 0) 
+    map_plt_rate = rospy.get_param("~map_plt_rate", 0) 
+    topic_map_server = TopicMapServer(topic_mappers, map_pub_rate, map_plt_rate)
+
+    # start mapping
+    for topic_mapper in topic_mappers:
+        topic_mapper.start()
+
+    rospy.spin()
+##########################################################################################

--- a/scripts/topic_mapping_node.py
+++ b/scripts/topic_mapping_node.py
@@ -3,7 +3,6 @@
 @author: Adam Binch (abinch@sagarobotics.com)
 """
 ##########################################################################################
-from __future__ import division
 from sentor.TopicMapper import TopicMapper
 from sentor.TopicMapServer import TopicMapServer
 from std_srvs.srv import Empty, EmptyResponse
@@ -28,22 +27,6 @@ def __signal_handler(signum, frame):
     join_mappers()
     print "stopped."
     os._exit(signal.SIGTERM)
-    
-
-def stop_mapping(_):
-    topic_map_server.stop()
-
-    rospy.logwarn("topic_mapping_node stopped mapping")
-    ans = EmptyResponse()
-    return ans
-    
-
-def start_mapping(_):
-    topic_map_server.start()
-
-    rospy.logwarn("topic_mapping_node started mapping")
-    ans = EmptyResponse()
-    return ans
 ##########################################################################################
     
 
@@ -59,9 +42,6 @@ if __name__ == "__main__":
     except Exception as e:
         rospy.logerr("No configuration file provided: %s" % e)
         topics = []
-
-    stop_srv = rospy.Service('/sentor/stop_mapping', Empty, stop_mapping)
-    start_srv = rospy.Service('/sentor/start_mapping', Empty, start_mapping)
 
     topic_mappers = []
     print "Mapping topics:"

--- a/src/sentor/TopicMapServer.py
+++ b/src/sentor/TopicMapServer.py
@@ -20,13 +20,13 @@ from std_srvs.srv import Empty, EmptyResponse
 class TopicMapServer(object):
     
 
-    def __init__(self, topic_monitors, map_pub_rate, map_plt_rate):
+    def __init__(self, topic_mappers, map_pub_rate, map_plt_rate):
         
         self.base_dir = os.path.join(os.path.expanduser("~"), ".sentor_maps")     
         if not os.path.exists(self.base_dir):
             os.mkdir(self.base_dir)    
         
-        self.topic_monitors = topic_monitors
+        self.topic_mappers = topic_mappers
 
         self._stop_event = Event()
 
@@ -42,26 +42,27 @@ class TopicMapServer(object):
             self.maps_pub = rospy.Publisher('/sentor/topic_maps', TopicMapArray, queue_size=10)
             rospy.Timer(rospy.Duration(1.0/map_pub_rate), self.publish_maps)
         
-        if map_plt_rate > 0:
-            if map_plt_rate > 1:
-                map_plt_rate = 1 
-            rospy.Timer(rospy.Duration(1.0/map_plt_rate), self.plot_maps)
+#        if map_plt_rate > 0:
+#            if map_plt_rate > 1:
+#                map_plt_rate = 1 
+#            rospy.Timer(rospy.Duration(1.0/map_plt_rate), self.plot_maps)
             
             
     def write_maps(self, req):
+        # broke after move to ubuntu 18
     
         message = "Saving maps: "
-        for monitor in self.topic_monitors:
-            if monitor.map is not None:
+        for mapper in self.topic_mappers:
+            if mapper.is_instantiated:
 
                 map_dir = os.path.join(self.base_dir, str(uuid.uuid4()))
                 os.mkdir(map_dir)
                 
-                _map = monitor.topic_mapper.map
+                _map = mapper.map
                 pickle.dump(_map, open(map_dir + "/topic_map.pkl", "wb"))
             
                 with open(map_dir + "/config.yaml",'w') as f:
-                    yaml.dump(monitor.map, f, default_flow_style=False)                
+                    yaml.dump(mapper.config, f, default_flow_style=False)                
                     
                 message = message + map_dir + " "
             
@@ -84,9 +85,9 @@ class TopicMapServer(object):
         
     def clear_maps(self, req):
         
-        for monitor in self.topic_monitors:
-            if monitor.map is not None:
-                monitor.topic_mapper.init_map()
+        for mapper in self.topic_mappers:
+            if mapper.is_instantiated:
+                mapper.init_map()
             
         ans = EmptyResponse()
         return ans
@@ -95,6 +96,7 @@ class TopicMapServer(object):
     def stop_mapping(self, req):
         self.stop()
         
+        rospy.logwarn("topic_mapping_node stopped mapping")
         ans = EmptyResponse()
         return ans
         
@@ -102,6 +104,7 @@ class TopicMapServer(object):
     def start_mapping(self, req):
         self.start()
         
+        rospy.logwarn("topic_mapping_node started mapping")
         ans = EmptyResponse()
         return ans
         
@@ -120,42 +123,43 @@ class TopicMapServer(object):
         if not self._stop_event.isSet():
             
             _id = 0
-            for monitor in self.topic_monitors:
-                if monitor.map is not None:     
-                    fig_id = "thread " + str(_id) + ": " + monitor.topic_name + " " + monitor.map["topic_arg"] + " " + monitor.map["stat"] 
+            for mapper in self.topic_mappers:
+                if mapper.is_instantiated:
+                
+                    fig_id = "thread " + str(_id) + ": " + mapper.topic_name + " " + mapper.config["arg"] + " " + mapper.config["stat"] 
                     
-                    _map = monitor.topic_mapper.map
+                    _map = mapper.map
                     masked_map = np.ma.array(_map, mask=np.isnan(_map))
                     
                     plt.pause(0.1)
                     plt.figure(fig_id); plt.clf()
                     plt.imshow(masked_map.T, interpolation="spline16", origin="lower", 
-                               extent=monitor.map["limits"])
+                               extent=mapper.config["limits"])
                     plt.colorbar()
                     plt.gca().set_aspect("equal", adjustable="box")
                     plt.tight_layout()
-        
+    
                 _id += 1
         
         
     def fill_msg(self, topic_maps):
         
-        for monitor in self.topic_monitors:
-            if monitor.map is not None:
+        for mapper in self.topic_mappers:
+            if mapper.is_instantiated:
                     
                 map_msg = TopicMap()
                 map_msg.header.stamp = rospy.Time.now()
                 map_msg.header.frame_id = "/map"
-                map_msg.topic_name = monitor.topic_name
-                map_msg.topic_arg = monitor.map["topic_arg"]
-                map_msg.stat = monitor.map["stat"]
-                map_msg.resolution = monitor.map["resolution"]
-                map_msg.shape = monitor.topic_mapper.shape
-                map_msg.index = monitor.topic_mapper.index
-                map_msg.position = monitor.topic_mapper.position
-                map_msg.arg_at_position = monitor.topic_mapper.arg_at_position
+                map_msg.topic_name = mapper.topic_name
+                map_msg.topic_arg = mapper.config["arg"]
+                map_msg.stat = mapper.config["stat"]
+                map_msg.resolution = mapper.config["resolution"]
+                map_msg.shape = mapper.shape
+                map_msg.index = mapper.index
+                map_msg.position = mapper.position
+                map_msg.arg_at_position = mapper.arg_at_position
     
-                topic_map = np.ndarray.tolist(np.ravel(monitor.topic_mapper.map))
+                topic_map = np.ndarray.tolist(np.ravel(mapper.map))
                 map_msg.topic_map = topic_map
             
                 topic_maps.topic_maps.append(map_msg)
@@ -167,16 +171,16 @@ class TopicMapServer(object):
 
         self._stop_event.set()    
         
-        for monitor in self.topic_monitors:
-            if monitor.map is not None:
-                monitor.topic_mapper.stop_mapping()
+        for mapper in self.topic_mappers:
+            if mapper.is_instantiated:
+                mapper.stop_mapping()
                 
         
     def start(self):
-
+        
         self._stop_event.clear()      
         
-        for monitor in self.topic_monitors:
-            if monitor.map is not None:
-                monitor.topic_mapper.start_mapping()
+        for mapper in self.topic_mappers:
+            if mapper.is_instantiated:
+                mapper.start_mapping()
 ##########################################################################################

--- a/src/sentor/TopicMonitor.py
+++ b/src/sentor/TopicMonitor.py
@@ -11,6 +11,7 @@ from sentor.Executor import Executor
 from sentor.TopicMapper import TopicMapper
 
 from threading import Thread, Event, Lock
+import socket
 import rostopic
 import rosgraph
 import rospy
@@ -33,7 +34,7 @@ class TopicMonitor(Thread):
 
 
     def __init__(self, topic_name, signal_when_config, signal_lambdas_config, processes, 
-                 timeout, default_notifications, _map, event_callback):
+                 timeout, default_notifications, event_callback):
         Thread.__init__(self)
 
         self.topic_name = topic_name
@@ -45,7 +46,6 @@ class TopicMonitor(Thread):
         else:
             self.timeout = 0.1
         self.default_notifications = default_notifications
-        self.map = _map
         self._event_callback = event_callback
         self.nodes = []
         
@@ -69,7 +69,6 @@ class TopicMonitor(Thread):
         
         if processes:
             self.executor = Executor(processes, self.event_callback)
-
 
 
     def _instantiate_monitors(self):
@@ -143,17 +142,15 @@ class TopicMonitor(Thread):
 
                     self.lambda_monitor_list.append(lambda_monitor)
             print ""
-            
-        if self.map is not None:
-            print "Mapping topic arg "+ bcolors.OKGREEN + self.map["topic_arg"] + bcolors.ENDC +" on topic "+ bcolors.OKBLUE + self.topic_name + bcolors.ENDC + '\n'
-            self.topic_mapper = TopicMapper(self.map, real_topic, msg_class) 
 
         self.is_instantiated = True
 
         return True
+    
 
     def event_callback(self, string, type, msg=""):
         self._event_callback(string, type, msg, self.nodes, self.topic_name)
+        
         
     def process_signal_config(self):
         


### PR DESCRIPTION
Topic mapping has its own node: `roslaunch sentor topic_mapping.launch`
Example config: `sentor/config/map.yaml`

Monitoring is unaffected by these changes.