### PR TITLE
Topic Mapping Improvements

### DIFF
--- a/config/map.yaml
+++ b/config/map.yaml
@@ -1,11 +1,12 @@
-- name : "/row_detector/health_monitor"
+- name: "/row_detector/health_monitor"
   arg: "msg.lines_accepted.data == False"
   stat: "mean"
   limits: [11.0, 25.0, -40.0, -8.0]
   resolution: 1.5
   include: True
 
-- name : "/row_detector/health_monitor"
+- name: "/row_detector/health_monitor"
+  rate: 5.0 
   arg: "msg.lines_accepted.data == False"
   stat: "std"
   limits: [11.0, 25.0, -40.0, -8.0]

--- a/config/map.yaml
+++ b/config/map.yaml
@@ -1,7 +1,9 @@
 - name: "/row_detector/health_monitor"
+  rate: 5.0 
   arg: "msg.lines_accepted.data == False"
   stat: "mean"
-  limits: [11.0, 25.0, -40.0, -8.0]
+  map: "/home/adam/rasberry_ws/src/thorvald_uv/thorvald_uv_bringup/config/uv_site_files/riseholme/rtk/map.yaml"
+#  limits: [11.0, 25.0, -40.0, -8.0]
   resolution: 1.5
   include: True
 

--- a/scripts/topic_mapping_node.py
+++ b/scripts/topic_mapping_node.py
@@ -43,7 +43,7 @@ if __name__ == "__main__":
 
     topic_mappers = []
     print "Mapping topics:"
-    for topic in topics:
+    for i, topic in enumerate(topics):
         try:
             topic_name = topic["name"]
         except Exception as e:
@@ -55,7 +55,7 @@ if __name__ == "__main__":
             include = topic["include"]
 
         if include:
-            topic_mappers.append(TopicMapper(topic))
+            topic_mappers.append(TopicMapper(topic, i))
             
     time.sleep(1)
     

--- a/scripts/topic_mapping_node.py
+++ b/scripts/topic_mapping_node.py
@@ -12,14 +12,12 @@ import rospy
 import time
 import yaml
 import os
-##########################################################################################
 
 
-##########################################################################################
 def __signal_handler(signum, frame):
     def kill_mappers():
         for topic_mapper in topic_mappers:
-            topic_mapper.kill_mapper()
+            topic_mapper.stop_mapping()
     def join_mappers():
         for topic_mapper in topic_mappers:
             topic_mapper.join()

--- a/src/sentor/TopicMapServer.py
+++ b/src/sentor/TopicMapServer.py
@@ -49,7 +49,6 @@ class TopicMapServer(object):
             
             
     def write_maps(self, req):
-        # broke after move to ubuntu 18
     
         message = "Saving maps: "
         for mapper in self.topic_mappers:
@@ -119,6 +118,7 @@ class TopicMapServer(object):
             
             
     def plot_maps(self, event=None):
+        # broke after move to ubuntu 18
         
         if not self._stop_event.isSet():
             


### PR DESCRIPTION
- Can set rate param in config to throttle topics. Useful when mapping topics with high publication rates.
- Topic map stat is selected at initialisation for efficiency.
- Can now retrieve topic map limits from metric map yaml files (see `map` arg in config)