### PR TITLE
Topic Monitoring Improvements.

### DIFF
--- a/config/example.yaml
+++ b/config/example.yaml
@@ -1,4 +1,5 @@
 - name : "/expr_1"
+  rate: 5.0
   signal_when:
     condition: "not published"
     timeout: 1.0

--- a/package.xml
+++ b/package.xml
@@ -26,6 +26,7 @@
   <build_depend>tf</build_depend>
   <build_depend>rosgraph</build_depend>
   <build_depend>dynamic_reconfigure</build_depend>
+  <build_depend>topic_tools</build_depend>
 
   <run_depend>rospy</run_depend>
   <run_depend>rostopic</run_depend>
@@ -37,6 +38,7 @@
   <run_depend>tf</run_depend>
   <run_depend>rosgraph</run_depend>
   <run_depend>dynamic_reconfigure</run_depend>
+  <run_depend>topic_tools</run_depend>
 
   <export>
     <!--<metapackage/> -->

--- a/scripts/sentor_node.py
+++ b/scripts/sentor_node.py
@@ -113,35 +113,39 @@ if __name__ == "__main__":
 
     topic_monitors = []
     print "Monitoring topics:"
-    for topic in topics:
+    for i, topic in enumerate(topics):
         try:
             topic_name = topic["name"]
         except Exception as e:
             rospy.logerr("topic name is not specified for entry %s" % topic)
             continue
 
+        rate = 0
         signal_when = {}
         signal_lambdas = []
         processes = []
         timeout = 0
         default_notifications = True
         include = True
-        if 'signal_when' in topic.keys():
+        
+        if 'rate' in topic:
+            rate = topic['rate']
+        if 'signal_when' in topic:
             signal_when = topic['signal_when']
-        if 'signal_lambdas' in topic.keys():
+        if 'signal_lambdas' in topic:
             signal_lambdas = topic['signal_lambdas']
-        if 'execute' in topic.keys():
+        if 'execute' in topic:
             processes = topic['execute']
-        if 'timeout' in topic.keys():
+        if 'timeout' in topic:
             timeout = topic['timeout']
-        if 'default_notifications' in topic.keys():
+        if 'default_notifications' in topic:
             default_notifications = topic['default_notifications']
-        if 'include' in topic.keys():
+        if 'include' in topic:
             include = topic['include']
 
         if include:
-            topic_monitor = TopicMonitor(topic_name, signal_when, signal_lambdas, processes, 
-                                         timeout, default_notifications, event_callback)
+            topic_monitor = TopicMonitor(topic_name, rate, signal_when, signal_lambdas, processes, 
+                                         timeout, default_notifications, event_callback, i)
 
             topic_monitors.append(topic_monitor)
             safety_monitor.register_monitors(topic_monitor)


### PR DESCRIPTION
Can set the topic rate in the config. More convenient than throttling topics in launch files.
If the topic rate is not set, then sentor subscribes to the original topic (as it does normally).

Service names (for the `call` process) and topic names (for the `publish` process) can now be retrieved from rosparams and environment variables. Sentor automatically checks the names provided in the config.

Processes are now not verbose by default.

Topic tools is a package dependency.

Some minor improvements.
