### PR TITLE
uint8[] to uint16[] to correctly read the info TOC

### DIFF
--- a/msg/ErrorCode.msg
+++ b/msg/ErrorCode.msg
@@ -1,1 +1,1 @@
-uint8[] error_code
+uint16[] error_code


### PR DESCRIPTION
change the type of `msg/ErrorCode.msg` from uint8[] to uint16[] as TOC couldn't correctly read the message (and cast it from uint8[]) - on the downside 2 bytes per element