### PR TITLE
Improvements

### DIFF
--- a/config/execute.yaml
+++ b/config/execute.yaml
@@ -4,7 +4,6 @@
   signal_lambdas:
   - expression: "lambda msg: msg.feedback.route == 't1-r1-c1'"
     safety_critical: True
-    default_notifications: True
     process_indices: [0,1,2,3,4,5]
     repeat_exec: False
     tags: ["navigation"]
@@ -13,7 +12,6 @@
     file: CustomLambdaExample
     package: sentor
     safety_critical: False
-    default_notifications: True
     process_indices: [6,7,8,9,10,11,12,13]
     repeat_exec: False
     tags: ["navigation"]
@@ -98,6 +96,7 @@
       -  "msg.pose.pose.position.y = -7.0"
       -  "msg.pose.pose.orientation.w = 1.0"
   timeout: 0.1
+  default_notifications: True
   include: True                  
 
 

--- a/config/execute.yaml
+++ b/config/execute.yaml
@@ -35,7 +35,7 @@
   - reconf:
       verbose: True
       params:
-      - ns: row_detector
+      - namespace: row_detector
         name: position_error_threshold
         value: -1
   - log:
@@ -58,9 +58,9 @@
   - reconf:
       verbose: True
       params:
-      - ns: row_detector
+      - namespace: row_detector
         name: position_error_threshold
-        value: 0.3
+        value: "_default"
   - log:
       message: "Row detection enabled"
       level: info

--- a/config/map.yaml
+++ b/config/map.yaml
@@ -1,7 +1,4 @@
 - name: "/topic_name"
-  rate: 5.0 
-  base_frame: "base_link"
-  map_frame: "map"
   arg: "msg.data"
   stat: "mean"
   limits: [11.0, 25.0, -40.0, -8.0]
@@ -9,7 +6,6 @@
   include: True
 
 - name: "/topic_name"
-  rate: 5.0 
   arg: "not msg.data"
   stat: "stdev"
   map: "/home/user/maps/map.yaml"

--- a/config/map.yaml
+++ b/config/map.yaml
@@ -1,5 +1,7 @@
 - name: "/topic_name"
   rate: 5.0 
+  base_frame: "base_link"
+  map_frame: "map"
   arg: "msg.data"
   stat: "mean"
   limits: [11.0, 25.0, -40.0, -8.0]
@@ -9,7 +11,7 @@
 - name: "/topic_name"
   rate: 5.0 
   arg: "not msg.data"
-  stat: "std"
+  stat: "stdev"
   map: "/home/user/maps/map.yaml"
   resolution: 1.5
   include: True

--- a/msg/TopicMap.msg
+++ b/msg/TopicMap.msg
@@ -1,4 +1,5 @@
 std_msgs/Header header
+string child_frame_id
 string topic_name
 string topic_arg
 string stat

--- a/scripts/topic_mapping_node.py
+++ b/scripts/topic_mapping_node.py
@@ -40,9 +40,6 @@ if __name__ == "__main__":
     except Exception as e:
         rospy.logerr("No configuration file provided: %s" % e)
         topics = []
-
-    map_frame = rospy.get_param("~map_frame", "map")         
-    base_frame = rospy.get_param("~base_frame", "base_link") 
     
     topic_mappers = []
     print "Mapping topics:"
@@ -58,7 +55,7 @@ if __name__ == "__main__":
             include = topic["include"]
 
         if include:
-            topic_mappers.append(TopicMapper(topic, map_frame, base_frame, i))
+            topic_mappers.append(TopicMapper(topic, i))
             
     time.sleep(1)
     

--- a/src/sentor/TopicMapServer.py
+++ b/src/sentor/TopicMapServer.py
@@ -57,8 +57,7 @@ class TopicMapServer(object):
                 map_dir = os.path.join(self.base_dir, str(uuid.uuid4()))
                 os.mkdir(map_dir)
                 
-                _map = mapper.map
-                pickle.dump(_map, open(map_dir + "/topic_map.pkl", "wb"))
+                pickle.dump(mapper.map, open(map_dir + "/topic_map.pkl", "wb"))
             
                 with open(map_dir + "/config.yaml",'w') as f:
                     yaml.dump(mapper.config, f, default_flow_style=False)                
@@ -149,7 +148,8 @@ class TopicMapServer(object):
                     
                 map_msg = TopicMap()
                 map_msg.header.stamp = rospy.Time.now()
-                map_msg.header.frame_id = "/map"
+                map_msg.header.frame_id = mapper.map_frame
+                map_msg.child_frame_id = mapper.base_frame
                 map_msg.topic_name = mapper.topic_name
                 map_msg.topic_arg = mapper.config["arg"]
                 map_msg.stat = mapper.config["stat"]
@@ -163,8 +163,8 @@ class TopicMapServer(object):
                 topic_maps.topic_maps.append(map_msg)
                 
         return topic_maps
-        
-                
+    
+    
     def stop(self):
 
         self._stop_event.set()    

--- a/src/sentor/TopicMapper.py
+++ b/src/sentor/TopicMapper.py
@@ -30,15 +30,23 @@ class bcolors:
 class TopicMapper(Thread):
     
     
-    def __init__(self, config, map_frame, base_frame, thread_num):
+    def __init__(self, config, thread_num):
         Thread.__init__(self)
         
         self.config = config
-        self.map_frame = map_frame
-        self.base_frame = base_frame
         self.thread_num = thread_num
-        
         self.topic_name = config["name"]
+        
+        self.map_frame = "map"
+        if "map_frame" in config:
+            self.map_frame = config["map_frame"]
+            
+        self.base_frame = "base_link"
+        if "base_frame" in config:
+            self.base_frame = config["base_frame"]
+            
+        self.config["map_frame"] = self.map_frame
+        self.config["base_frame"] = self.base_frame
         
         self.set_limits()
         self.config["limits"] = [self.x_min, self.x_max, self.y_min, self.y_max]
@@ -85,7 +93,7 @@ class TopicMapper(Thread):
         self.map = np.zeros((self.nx, self.ny))  
         self.map[:] = np.nan
         
-        if self.config["stat"] == "std":
+        if self.config["stat"] == "stdev":
             self.wma = np.zeros((self.nx, self.ny))
             self.wma[:] = np.nan
             
@@ -104,7 +112,7 @@ class TopicMapper(Thread):
         elif self.config["stat"] == "max":
             stat = self._max
             
-        elif self.config["stat"] == "std":
+        elif self.config["stat"] == "stdev":
             stat = self._std
             
         else:
@@ -185,7 +193,7 @@ class TopicMapper(Thread):
             try:
                 x, y = self.get_transform()
             except: 
-                rospy.logwarn("Failed to get transform between the map and baselink frames")
+                rospy.logwarn("Failed to get tf transform between {} and {}".format(self.map_frame, self.base_frame))
                 return
                 
             if self.x_min <= x <= self.x_max and self.y_min <= y <= self.y_max:  


### PR DESCRIPTION
For the `reconf` process you can now set the value of a param in the config to `_default` which reconfigures the param back to its original state.
The argument for the param's namespace has been changed from `ns` to `namespace`.
For topic mapping you no longer set the map and base frames as a rosparam (i.e in a launch file) but in the config instead, allowing maps using different tf transforms to be created simultaneously.
The topic map msg now includes a field for the base frame (`child_frame_id`).
For topic mapping the `stat` arg for the standard deviation has been changed from `std` to `stdev`.
Some general tidying.