### PR TITLE
Can now pass a list of config files, which sentor will concatenate into one config.

### DIFF
--- a/config/example.yaml
+++ b/config/example.yaml
@@ -41,13 +41,6 @@
   - log:
       message: "expression 1 is not published"
       level: "warn"
-#  - custom:
-#      package: "rasberry_uv"
-#      name: myClass
-#      init_args:
-#      - "Hello"
-#      run_args:
-#      - "World"
   timeout: 0.1
   default_notifications: True
   include: True

--- a/scripts/sentor_node.py
+++ b/scripts/sentor_node.py
@@ -97,9 +97,12 @@ if __name__ == "__main__":
     rospy.init_node("sentor")
 
     config_file = rospy.get_param("~config_file", "")
-
     try:
-        topics = yaml.load(file(config_file, 'r'))
+        if config_file[0] == "[" and config_file[-1] == "]":
+            items = [yaml.load(file(item, 'r')) for item in eval(config_file)]
+            topics = [item for sublist in items for item in sublist]
+        else:
+            topics = yaml.load(file(config_file, 'r'))
     except Exception as e:
         rospy.logerr("No configuration file provided: %s" % e)
         topics = []


### PR DESCRIPTION
Example launch command:
`roslaunch sentor sentor.launch config_file:="['$(rospack find sentor)/config/example_1.yaml','$(rospack find sentor)/config/example_2.yaml']"`