### PR TITLE
Allowing to pass a shell command with shell=True in Popen

### DIFF
--- a/src/sentor/Executor.py
+++ b/src/sentor/Executor.py
@@ -205,6 +205,7 @@ class Executor(object):
             d["func"] = "self.shell(**kwargs)"
             d["kwargs"] = {}
             d["kwargs"]["cmd_args"] = process["shell"]["cmd_args"]
+            d["kwargs"]["shell_features"] = process["shell"]["shell_features"] if "shell_features" in process["shell"] else False
             
             self.processes.append(d)
 
@@ -410,9 +411,10 @@ class Executor(object):
         rospy.sleep(duration)
         
         
-    def shell(self, cmd_args):
+    def shell(self, cmd_args, shell_features):
         
         process = subprocess.Popen(cmd_args,
+                     shell=shell_features,
                      stdout=subprocess.PIPE, 
                      stderr=subprocess.PIPE)
                      


### PR DESCRIPTION
It will allow for example to launch a shell command like this:
```
    - shell:
        verbose: True
        shell_features: True
        cmd_args: ". $HOME/.rasberryrc; tmule -c $CATKIN_WORKSPACE/src/RASberry/rasberry_bringup/tmule/rasberry-robot-rfid.yaml relaunch -t reset_rfid_lidar"
```
where you can concatenate multiple commands and access the envronment variables.

The cmd_args parameter in this case is a string, while if `shell_features=False` has to be a list, like before.