### PR TITLE
Conditions can now be tagged as `autonomy_critical`. 

### DIFF
--- a/config/test.yaml
+++ b/config/test.yaml
@@ -1,5 +1,5 @@
 # sentor/test.py publishes these topics expr_1 and expr_2. 
-# call services /pub_expr_1 and /set_expr_1 to start/stop publishing and set the topic arg, respectively. Same for expr_2.
+# call services /pub_expr_1 and /set_expr_1 to start/stop publishing and set the topic arg (True/False), respectively. Same for expr_2.
 
 - name : "/expr_1"
   signal_when:
@@ -12,6 +12,7 @@
   - expression: "lambda msg : msg.data == False"
     timeout: 5.0
     safety_critical: True
+    autonomy_critical: True
     process_indices: [1]
     tags: ["expression 1"]
   execute:
@@ -35,6 +36,7 @@
   - expression: "lambda msg : msg.data == False"
     timeout: 10.0
     safety_critical: True
+    autonomy_critical: False
     process_indices: [1]
     tags: ["expression 2"]
   execute:
@@ -59,6 +61,23 @@
       level: warn
   - log:
       message: "Safe to operate"
+      level: info
+  timeout: 0.1
+  default_notifications: False
+
+
+- name: "/safe_autonomous_operation"
+  signal_lambdas:
+    - expression: "lambda msg : msg.data == False"
+      process_indices: [0]
+    - expression: "lambda msg : msg.data == True"
+      process_indices: [1]
+  execute:
+  - log:
+      message: "Not safe to operate autonomously"
+      level: warn
+  - log:
+      message: "Safe to operate autonomously"
       level: info
   timeout: 0.1
   default_notifications: False

--- a/launch/sentor.launch
+++ b/launch/sentor.launch
@@ -6,6 +6,7 @@
   <arg name="safe_operation_timeout" default="10.0"/>
   <arg name="auto_safety_tagging" default="true"/>
   <arg name="safety_pub_rate" default="10.0"/>
+  <arg name="independent_tags" default="false"/>
 
 
   <node pkg="sentor" type="sentor_node.py" name="sentor" output="screen">
@@ -13,6 +14,7 @@
     <param name="~safe_operation_timeout" value="$(arg safe_operation_timeout)" />
     <param name="~auto_safety_tagging" value="$(arg auto_safety_tagging)" />
     <param name="~safety_pub_rate" value="$(arg safety_pub_rate)" />
+    <param name="~independent_tags" value="$(arg independent_tags)" />
   </node>	
 
 </launch>

--- a/msg/Monitor.msg
+++ b/msg/Monitor.msg
@@ -1,5 +1,6 @@
 string topic
 string condition
 bool safety_critical
+bool autonomy_critical
 bool satisfied
 string[] tags

--- a/scripts/sentor_node.py
+++ b/scripts/sentor_node.py
@@ -109,12 +109,9 @@ if __name__ == "__main__":
 
     event_pub = rospy.Publisher('/sentor/event', String, queue_size=10)
     rich_event_pub = rospy.Publisher('/sentor/rich_event', SentorEvent, queue_size=10)
-
-    safe_operation_timeout = rospy.get_param("~safe_operation_timeout", 10.0)    
-    safety_pub_rate = rospy.get_param("~safety_pub_rate", 10.0)    
-    auto_safety_tagging = rospy.get_param("~auto_safety_tagging", True)        
-    safety_monitor = SafetyMonitor(safe_operation_timeout, safety_pub_rate, auto_safety_tagging, event_callback) 
     
+    safety_monitor = SafetyMonitor("safe_operation", "thread_is_safe", "set_safety_tag", event_callback)
+    autonomy_monitor = SafetyMonitor("safe_autonomous_operation", "thread_is_auto", "set_autonomy_tag", event_callback)
     multi_monitor = MultiMonitor()
 
     topic_monitors = []
@@ -162,6 +159,7 @@ if __name__ == "__main__":
 
         topic_monitors.append(topic_monitor)
         safety_monitor.register_monitors(topic_monitor)
+        autonomy_monitor.register_monitors(topic_monitor)
         multi_monitor.register_monitors(topic_monitor)
             
     time.sleep(1)

--- a/scripts/sentor_node.py
+++ b/scripts/sentor_node.py
@@ -31,14 +31,19 @@ event_pub = None
 rich_event_pub = None
 
 def __signal_handler(signum, frame):
+
     def kill_monitors():
         for topic_monitor in topic_monitors:
             topic_monitor.kill_monitor()
+
         safety_monitor.stop_monitor()
+        autonomy_monitor.stop_monitor()
         multi_monitor.stop_monitor()
+
     def join_monitors():
         for topic_monitor in topic_monitors:
             topic_monitor.join()
+
     kill_monitors()
     join_monitors()
     print "stopped."
@@ -50,6 +55,7 @@ def stop_monitoring(_):
         topic_monitor.stop_monitor()
         
     safety_monitor.stop_monitor()
+    autonomy_monitor.stop_monitor()
     multi_monitor.stop_monitor()
 
     rospy.logwarn("sentor_node stopped monitoring")
@@ -62,6 +68,7 @@ def start_monitoring(_):
         topic_monitor.start_monitor()
 
     safety_monitor.start_monitor()
+    autonomy_monitor.start_monitor()
     multi_monitor.start_monitor()
 
     rospy.logwarn("sentor_node started monitoring")

--- a/src/sentor/Executor.py
+++ b/src/sentor/Executor.py
@@ -11,6 +11,11 @@ import os, numpy, math
 from threading import Lock
 
 
+def _import(location, name):
+    mod = __import__(location, fromlist=[name]) 
+    return getattr(mod, name) 
+
+
 class Executor(object):
     
     
@@ -138,9 +143,9 @@ class Executor(object):
             package = process["action"]["package"]
             spec = process["action"]["action_spec"]
             
-            exec("from {}.msg import {} as action_spec".format(package, spec))
-            exec("from {}.msg import {} as goal_class".format(package, spec[:-6] + "Goal"))
-            
+            action_spec = _import(package+".msg", spec)
+            goal_class = _import(package+".msg", spec[:-6] + "Goal")
+
             rospy.sleep(1.0)
             
             action_client = actionlib.SimpleActionClient(namespace, action_spec)
@@ -308,7 +313,7 @@ class Executor(object):
             if "file" in process["custom"]:
                 _file = process["custom"]["file"]
             
-            exec("from {}.{} import {} as custom_proc".format(package, _file, name))
+            custom_proc = _import("{}.{}".format(package, _file), name)
             
             if "init_args" in process["custom"]:
                 args = process["custom"]["init_args"] 

--- a/src/sentor/MultiMonitor.py
+++ b/src/sentor/MultiMonitor.py
@@ -14,7 +14,9 @@ from threading import Event
 class MultiMonitor(object):
     
     
-    def __init__(self, rate=10):
+    def __init__(self):
+
+        rate = rospy.get_param("~safety_pub_rate", 10.0) 
         
         self.topic_monitors = []
         self._stop_event = Event()
@@ -49,6 +51,7 @@ class MultiMonitor(object):
                         condition.topic = topic_name
                         condition.condition = expr
                         condition.safety_critical = monitor.conditions[expr]["safety_critical"]
+                        condition.autonomy_critical = monitor.conditions[expr]["autonomy_critical"]
                         condition.satisfied = self.error_code[count]
                         condition.tags = monitor.conditions[expr]["tags"]
                         conditions.conditions.append(condition)

--- a/src/sentor/ROSTopicFilter.py
+++ b/src/sentor/ROSTopicFilter.py
@@ -8,6 +8,11 @@ from __future__ import division
 import rospy, math, numpy
 # imported the packages math and numpy so that they can be used in the lambda expressions
 
+def _import(location, name):
+    mod = __import__(location, fromlist=[name]) 
+    return getattr(mod, name) 
+
+
 class ROSTopicFilter(object):
 
     def __init__(self, topic_name, lambda_fn_str, config, throttle_val):
@@ -21,8 +26,7 @@ class ROSTopicFilter(object):
         self.lambda_fn = None
         try:
             if config["file"] is not None and config["package"] is not None:
-                exec("from {}.{} import {} as lambda_fn".format(config["package"], config["file"], self.lambda_fn_str))
-                self.lambda_fn = lambda_fn
+                self.lambda_fn = _import("{}.{}".format(config["package"], config["file"]), self.lambda_fn_str)
             else:
                 self.lambda_fn = eval(self.lambda_fn_str)
         except Exception as e:

--- a/src/sentor/TopicMonitor.py
+++ b/src/sentor/TopicMonitor.py
@@ -71,6 +71,8 @@ class TopicMonitor(Thread):
         self.is_instantiated = False
         self.is_instantiated = self._instantiate_monitors()
         
+        self.independent_tags = rospy.get_param("~independent_tags", False)
+        
         self.signal_when_is_safe = True
         self.lambdas_are_safe = True
         self.thread_is_safe = True
@@ -353,7 +355,10 @@ class TopicMonitor(Thread):
             while not self._stop_event.isSet():
                 
                 self.thread_is_safe = self.signal_when_is_safe and self.lambdas_are_safe
-                self.thread_is_auto = self.thread_is_safe and self.signal_when_is_auto and self.lambdas_are_auto
+                if not self.independent_tags:
+                    self.thread_is_auto = self.thread_is_safe and self.signal_when_is_auto and self.lambdas_are_auto
+                else:
+                    self.thread_is_auto = self.signal_when_is_auto and self.lambdas_are_auto
                 
                 # check it is still published (None if not)
                 if self.hz_monitor is not None:


### PR DESCRIPTION
Working much like safety critical conditions, if any autonomy critical condition from any topic monitor is satisfied then the boolean message from the topic `/safe_autonomous_operation` will be set to False.

By default, if sentor hears that all of the autonomy critical conditions that it listens to are unsatisfied for `safe_operation_timeout` seconds then `safe_autonomous_operation` will be set to True.

If param `/sentor/independent_tags` is False (default) then It is possible to have safe operation without safe autonomous operation, but it is not possible to have safe autonomous operation without safe operation, else each tag works independently.

Executor and ROSTopicFilter imports objects properly, rather than using python's `exec`.