### PR TITLE
Add invert option so that sentor can publish a twist_mux friendly pause_navigation topic

### DIFF
--- a/scripts/sentor_node.py
+++ b/scripts/sentor_node.py
@@ -117,8 +117,8 @@ if __name__ == "__main__":
     event_pub = rospy.Publisher('/sentor/event', String, queue_size=10)
     rich_event_pub = rospy.Publisher('/sentor/rich_event', SentorEvent, queue_size=10)
     
-    safety_monitor = SafetyMonitor("safe_operation", "thread_is_safe", "set_safety_tag", event_callback)
-    autonomy_monitor = SafetyMonitor("safe_autonomous_operation", "thread_is_auto", "set_autonomy_tag", event_callback)
+    safety_monitor = SafetyMonitor("safe_operation", "SAFE OPERATION", "thread_is_safe", "set_safety_tag", event_callback)
+    autonomy_monitor = SafetyMonitor("pause_autonomous_operation", "SAFE AUTONOMOUS OPERATION", "thread_is_auto", "set_autonomy_tag", event_callback, invert=True)
     multi_monitor = MultiMonitor()
 
     topic_monitors = []


### PR DESCRIPTION
Previously hard coded so the safety topics are true if monitor conditions are met and false otherwise.

To work with twist_mux we need the opposite so added an invert option. Then we can use a topic such as pause_navigation to add a lock to twist_mux, see [3.1.2 Lock inputs](https://wiki.ros.org/twist_mux#Subscribers)